### PR TITLE
SecurityCoordinator: fix build error (printing bug)

### DIFF
--- a/apps/system/components/SecurityCoordinator/cantrip-security-coordinator/src/fakeimpl/mod.rs
+++ b/apps/system/components/SecurityCoordinator/cantrip-security-coordinator/src/fakeimpl/mod.rs
@@ -33,7 +33,7 @@ use cantrip_security_interface::*;
 use core::mem::size_of;
 use core::ptr;
 use core::slice;
-use cpio::CpioNewcReader;
+use cpio::{CpioNewcReader, Object};
 use hashbrown::HashMap;
 use log::{error, info};
 
@@ -142,7 +142,8 @@ fn get_builtins() -> BundleIdArray {
     let mut builtins = BundleIdArray::new();
     for e in CpioNewcReader::new(cpio_archive_ref) {
         if e.is_err() {
-            error!("cpio read err {:?}", e);
+            let Object { name, .. } = e.unwrap();
+            error!("cpio read err {:?}", name);
             break;
         }
         builtins.push(e.unwrap().name.to_string());
@@ -159,7 +160,8 @@ fn get_bundle_from_builtins(filename: &str) -> Result<BundleData, SecurityReques
         };
         for e in CpioNewcReader::new(cpio_archive_ref) {
             if e.is_err() {
-                error!("cpio read err {:?}", e);
+                let Object { name, .. } = e.unwrap();
+                error!("cpio read err {:?}", name);
                 break;
             }
             let entry = e.unwrap();


### PR DESCRIPTION
building for rpi3 causes the following error:
```
error[E0277]: `Object<'_>` doesn't implement `core::fmt::Debug`
   --> cantrip-security-coordinator/src/fakeimpl/mod.rs:145:42
    |
145 |             error!("cpio read err {:?}", e);
    |                                          ^ `Object<'_>` cannot be formatted using `{:?}` because it doesn't implement `core::fmt::Debug`
    |
    = help: the trait `core::fmt::Debug` is not implemented for `Object<'_>`
    = help: the trait `core::fmt::Debug` is implemented for `Result<T, E>`
    = note: this error originates in the macro `format_args` which comes from the expansion of the macro `error` (in Nightly builds, run with -Z macro-backtrace for more info)
```

This commit should fix it.